### PR TITLE
fix overlap of long sqon entries on the count of participants

### DIFF
--- a/modules/components/package-lock.json
+++ b/modules/components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kfarranger/components",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/modules/components/package.json
+++ b/modules/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kfarranger/components",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Data Portal Components",
   "main": "dist/index.js",
   "publishConfig": {

--- a/modules/components/src/AdvancedSqonBuilder/style.css
+++ b/modules/components/src/AdvancedSqonBuilder/style.css
@@ -40,7 +40,7 @@
   border: solid 1px lightgrey;
   margin-top: 4px;
   margin-bottom: 4px;
-  padding-right: 100px;
+  padding-right: 185px;
   min-height: 40px;
 }
 .sqonEntry:hover {
@@ -114,7 +114,7 @@
 
 .sqonEntry .participantsCountContainer {
   position: absolute;
-  width: 6em;
+  width: 75px;
   right: 100px;
   height: 100%;
   display: flex;


### PR DESCRIPTION
Fix for: https://github.com/kids-first/kf-portal-ui/issues/1872